### PR TITLE
feat: Maven, Ruby, Go parsers + R7 terminal summary fix

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -104,6 +104,7 @@ func runScan(args []string, stdout io.Writer, stderr io.Writer) int {
 	if *includeVulnerabilities {
 		if vulnerability.IsGrypeAvailable() {
 			_, _ = fmt.Fprintf(stdout, "Vulnerability scanning: enabled (Grype)\n")
+
 		} else {
 			_, _ = fmt.Fprintf(stderr, "WARNING: Vulnerability scanning requested but Grype not found in PATH\n")
 			_, _ = fmt.Fprintf(stderr, "Install Grype from: https://github.com/anchore/grype\n")
@@ -130,7 +131,7 @@ func runScan(args []string, stdout io.Writer, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stdout, "- %s  %s  [%s]\n", repo.Name, repo.Path, stack)
 		printDependencySummary(stdout, stderr, repo.Name, repo.Path, detection, selectedFormat, *includeVulnerabilities)
 	}
-
+	_, _ = fmt.Fprintf(stdout, "\nScan complete: %d repositories scanned\n", len(repos))
 	return 0
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,8 +13,11 @@ import (
 	"github.com/Xsamsx/SBOMber/internal/deps"
 	"github.com/Xsamsx/SBOMber/internal/discovery"
 	"github.com/Xsamsx/SBOMber/internal/ecosystem"
+	"github.com/Xsamsx/SBOMber/internal/golang"
+	"github.com/Xsamsx/SBOMber/internal/maven"
 	"github.com/Xsamsx/SBOMber/internal/npm"
 	"github.com/Xsamsx/SBOMber/internal/python"
+	"github.com/Xsamsx/SBOMber/internal/ruby"
 	"github.com/Xsamsx/SBOMber/internal/sbom"
 	"github.com/Xsamsx/SBOMber/internal/vulnerability"
 )
@@ -290,13 +293,18 @@ func printDependencySummary(stdout io.Writer, stderr io.Writer, repoName, repoPa
 		}
 	}
 
-	if !containsEcosystem(detection.Names, ecosystem.NPM) && !containsEcosystem(detection.Names, ecosystem.Python) {
+	totalDirect := summary.Count()
+	totalTransitive := summary.TransitiveCount()
+
+	if totalDirect == 0 && totalTransitive == 0 {
 		return
 	}
 
-	if summary.Count() == 0 {
-		return
+	_, _ = fmt.Fprintf(stdout, "  packages:  %d direct", totalDirect)
+	if totalTransitive > 0 {
+		_, _ = fmt.Fprintf(stdout, ", %d transitive (%d total)", totalTransitive, summary.TotalCount())
 	}
+	_, _ = fmt.Fprintln(stdout)
 
 	sourceLabel := "package.json"
 	if containsEcosystem(detection.Names, ecosystem.Python) {
@@ -380,6 +388,30 @@ func buildRepoDependencySummary(repoPath string, detection ecosystem.Detection) 
 		summary.Direct = append(summary.Direct, pythonSummary.Direct...)
 		summary.Transitive = append(summary.Transitive, pythonSummary.Transitive...)
 	}
+	if containsEcosystem(detection.Names, ecosystem.Maven) {
+		mavenSummary, err := maven.ParsePOM(repoPath)
+		if err != nil {
+			return deps.Summary{}, err
+		}
+		summary.Direct = append(summary.Direct, mavenSummary.Direct...)
+	}
+
+	if containsEcosystem(detection.Names, ecosystem.Ruby) {
+		rubySummary, err := ruby.ParseGemfileLock(repoPath)
+		if err != nil {
+			return deps.Summary{}, err
+		}
+		summary.Direct = append(summary.Direct, rubySummary.Direct...)
+	}
+
+	if containsEcosystem(detection.Names, ecosystem.Go) {
+		goSummary, err := golang.ParseGoMod(repoPath)
+		if err != nil {
+			return deps.Summary{}, err
+		}
+		summary.Direct = append(summary.Direct, goSummary.Direct...)
+		summary.Transitive = append(summary.Transitive, goSummary.Transitive...)
+	}
 
 	return summary, nil
 }
@@ -431,7 +463,7 @@ func reportSPDXVulnerabilities(stdout io.Writer, stderr io.Writer, spdxPath stri
 
 	_, _ = fmt.Fprintf(stdout, "    total vulnerabilities found: %d\n", vulnResults.TotalCount)
 	for _, vuln := range vulnResults.Vulnerabilities {
-		_, _ = fmt.Fprintf(stdout, "      - %s [%s] package=%s type=%s\n", vuln.Vulnerability, strings.ToUpper(vuln.Severity[:1]) + strings.ToLower(vuln.Severity[1:]), vuln.PackageName, vuln.PackageType)
+		_, _ = fmt.Fprintf(stdout, "      - %s [%s] package=%s type=%s\n", vuln.Vulnerability, strings.ToUpper(vuln.Severity[:1])+strings.ToLower(vuln.Severity[1:]), vuln.PackageName, vuln.PackageType)
 	}
 }
 

--- a/internal/golang/parse.go
+++ b/internal/golang/parse.go
@@ -1,0 +1,126 @@
+package golang
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Xsamsx/SBOMber/internal/deps"
+)
+
+// ParseGoMod reads a go.mod file and returns a normalized dependency summary.
+// Modules marked with "// indirect" are recorded as transitive dependencies.
+// All other entries in the require block are recorded as direct dependencies.
+func ParseGoMod(root string) (deps.Summary, error) {
+	path := filepath.Join(root, "go.mod")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return deps.Summary{
+				Direct:     make([]deps.Dependency, 0),
+				Transitive: make([]deps.Dependency, 0),
+			}, nil
+		}
+		return deps.Summary{}, fmt.Errorf("read go.mod: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	summary := deps.Summary{
+		Direct:     make([]deps.Dependency, 0),
+		Transitive: make([]deps.Dependency, 0),
+	}
+
+	inRequireBlock := false
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Opening of a require block: "require ("
+		if trimmed == "require (" {
+			inRequireBlock = true
+			continue
+		}
+
+		// Closing of a require block: ")"
+		if trimmed == ")" && inRequireBlock {
+			inRequireBlock = false
+			continue
+		}
+
+		// Single-line require outside a block: "require module/path v1.2.3"
+		if strings.HasPrefix(trimmed, "require ") && !inRequireBlock {
+			remainder := strings.TrimPrefix(trimmed, "require ")
+			isIndirect := strings.Contains(remainder, "// indirect")
+			if idx := strings.Index(remainder, "//"); idx != -1 {
+				remainder = strings.TrimSpace(remainder[:idx])
+			}
+			parts := strings.Fields(remainder)
+			if len(parts) >= 2 {
+				dep := deps.Dependency{
+					Name:    parts[0],
+					Version: parts[1],
+					Scope:   deps.ScopeRuntime,
+				}
+				if isIndirect {
+					summary.Transitive = append(summary.Transitive, dep)
+				} else {
+					summary.Direct = append(summary.Direct, dep)
+				}
+			}
+			continue
+		}
+
+		if !inRequireBlock {
+			continue
+		}
+
+		// Skip blank lines and pure comments inside require block
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+
+		// Inside a require block: "    module/path v1.2.3 // indirect"
+		isIndirect := strings.Contains(line, "// indirect")
+
+		// Strip the inline comment before splitting into parts
+		clean := trimmed
+		if idx := strings.Index(clean, "//"); idx != -1 {
+			clean = strings.TrimSpace(clean[:idx])
+		}
+
+		parts := strings.Fields(clean)
+		if len(parts) < 2 {
+			continue
+		}
+
+		dep := deps.Dependency{
+			Name:    parts[0],
+			Version: parts[1],
+			Scope:   deps.ScopeRuntime,
+		}
+
+		if isIndirect {
+			summary.Transitive = append(summary.Transitive, dep)
+		} else {
+			summary.Direct = append(summary.Direct, dep)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return deps.Summary{}, fmt.Errorf("scan go.mod: %w", err)
+	}
+
+	sort.SliceStable(summary.Direct, func(i, j int) bool {
+		return summary.Direct[i].Name < summary.Direct[j].Name
+	})
+	sort.SliceStable(summary.Transitive, func(i, j int) bool {
+		return summary.Transitive[i].Name < summary.Transitive[j].Name
+	})
+
+	return summary, nil
+}

--- a/internal/golang/parse_test.go
+++ b/internal/golang/parse_test.go
@@ -1,0 +1,48 @@
+package golang
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseGoMod(t *testing.T) {
+	root := filepath.Join("..", "..", "testdata", "fixtures", "go-basic")
+	summary, err := ParseGoMod(root)
+	if err != nil {
+		t.Fatalf("ParseGoMod failed: %v", err)
+	}
+
+	if len(summary.Direct) != 1 {
+		t.Errorf("expected 1 direct dependency, got %d", len(summary.Direct))
+	}
+	if len(summary.Transitive) != 1 {
+		t.Errorf("expected 1 transitive dependency, got %d", len(summary.Transitive))
+	}
+
+	if summary.Direct[0].Name != "github.com/gin-gonic/gin" {
+		t.Errorf("expected gin as direct dep, got %s", summary.Direct[0].Name)
+	}
+	if summary.Direct[0].Version != "v1.9.1" {
+		t.Errorf("expected gin version v1.9.1, got %s", summary.Direct[0].Version)
+	}
+
+	if summary.Transitive[0].Name != "golang.org/x/crypto" {
+		t.Errorf("expected crypto as transitive dep, got %s", summary.Transitive[0].Name)
+	}
+	if summary.Transitive[0].Version != "v0.14.0" {
+		t.Errorf("expected crypto version v0.14.0, got %s", summary.Transitive[0].Version)
+	}
+}
+
+func TestParseGoModNotFound(t *testing.T) {
+	summary, err := ParseGoMod("/nonexistent/path/that/does/not/exist")
+	if err != nil {
+		t.Fatalf("expected no error for missing go.mod, got: %v", err)
+	}
+	if len(summary.Direct) != 0 {
+		t.Errorf("expected 0 direct deps, got %d", len(summary.Direct))
+	}
+	if len(summary.Transitive) != 0 {
+		t.Errorf("expected 0 transitive deps, got %d", len(summary.Transitive))
+	}
+}

--- a/internal/maven/parse.go
+++ b/internal/maven/parse.go
@@ -1,0 +1,67 @@
+package maven
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Xsamsx/SBOMber/internal/deps"
+)
+
+type pomXML struct {
+	Dependencies struct {
+		Dependency []pomDependency `xml:"dependency"`
+	} `xml:"dependencies"`
+}
+
+type pomDependency struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+	Scope      string `xml:"scope"`
+}
+
+func ParsePOM(root string) (deps.Summary, error) {
+	path := filepath.Join(root, "pom.xml")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return deps.Summary{Direct: make([]deps.Dependency, 0)}, nil
+		}
+		return deps.Summary{}, fmt.Errorf("read pom.xml: %w", err)
+	}
+
+	var pom pomXML
+	if err := xml.Unmarshal(content, &pom); err != nil {
+		return deps.Summary{}, fmt.Errorf("parse pom.xml: %w", err)
+	}
+
+	summary := deps.Summary{
+		Direct: make([]deps.Dependency, 0, len(pom.Dependencies.Dependency)),
+	}
+
+	for _, dep := range pom.Dependencies.Dependency {
+		if dep.GroupID == "" || dep.ArtifactID == "" {
+			continue
+		}
+
+		scope := deps.ScopeRuntime
+		if dep.Scope == "test" {
+			scope = deps.ScopeDev
+		}
+
+		summary.Direct = append(summary.Direct, deps.Dependency{
+			Name:    dep.GroupID + ":" + dep.ArtifactID,
+			Version: dep.Version,
+			Scope:   scope,
+		})
+	}
+
+	sort.SliceStable(summary.Direct, func(i, j int) bool {
+		return summary.Direct[i].Name < summary.Direct[j].Name
+	})
+
+	return summary, nil
+}

--- a/internal/maven/parse_test.go
+++ b/internal/maven/parse_test.go
@@ -1,0 +1,17 @@
+package maven
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePOM(t *testing.T) {
+	root := filepath.Join("..", "..", "testdata", "fixtures", "maven-basic")
+	summary, err := ParsePOM(root)
+	if err != nil {
+		t.Fatalf("ParsePOM failed: %v", err)
+	}
+	if len(summary.Direct) != 2 {
+		t.Errorf("expected 2 direct dependencies, got %d", len(summary.Direct))
+	}
+}

--- a/internal/ruby/parse.go
+++ b/internal/ruby/parse.go
@@ -1,0 +1,106 @@
+package ruby
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Xsamsx/SBOMber/internal/deps"
+)
+
+// ParseGemfileLock reads a Gemfile.lock file and returns a normalized dependency summary.
+// All gems in the GEM specs: section are returned as direct dependencies.
+// Distinguishing direct from transitive requires cross-referencing Gemfile and
+// is deferred to Semester 2.
+func ParseGemfileLock(root string) (deps.Summary, error) {
+	path := filepath.Join(root, "Gemfile.lock")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return deps.Summary{Direct: make([]deps.Dependency, 0)}, nil
+		}
+		return deps.Summary{}, fmt.Errorf("read Gemfile.lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	summary := deps.Summary{
+		Direct: make([]deps.Dependency, 0),
+	}
+
+	inGemSection := false
+	inSpecsSection := false
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Detect start of the GEM section
+		if trimmed == "GEM" {
+			inGemSection = true
+			inSpecsSection = false
+			continue
+		}
+
+		// Detect start of the specs: block inside GEM
+		if trimmed == "specs:" && inGemSection {
+			inSpecsSection = true
+			continue
+		}
+
+		// Any non-indented line that is not "specs:" ends the GEM block
+		if inGemSection && len(line) > 0 && line[0] != ' ' && trimmed != "specs:" {
+			inGemSection = false
+			inSpecsSection = false
+			continue
+		}
+
+		if !inSpecsSection {
+			continue
+		}
+
+		// Gem entries are indented exactly 4 spaces: "    gemname (version)"
+		// Sub-dependencies are indented 6+ spaces — skip those
+		if !strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "      ") {
+			continue
+		}
+
+		// Parse "    gemname (version)"
+		entry := strings.TrimSpace(line)
+		openParen := strings.Index(entry, " (")
+		if openParen == -1 {
+			continue
+		}
+
+		name := strings.TrimSpace(entry[:openParen])
+		rest := entry[openParen+2:]
+		closeParen := strings.Index(rest, ")")
+		if closeParen == -1 {
+			continue
+		}
+		version := strings.TrimSpace(rest[:closeParen])
+
+		if name == "" {
+			continue
+		}
+
+		summary.Direct = append(summary.Direct, deps.Dependency{
+			Name:    name,
+			Version: version,
+			Scope:   deps.ScopeRuntime,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return deps.Summary{}, fmt.Errorf("scan Gemfile.lock: %w", err)
+	}
+
+	sort.SliceStable(summary.Direct, func(i, j int) bool {
+		return summary.Direct[i].Name < summary.Direct[j].Name
+	})
+
+	return summary, nil
+}

--- a/internal/ruby/parse_test.go
+++ b/internal/ruby/parse_test.go
@@ -1,0 +1,55 @@
+package ruby
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseGemfileLock(t *testing.T) {
+	root := filepath.Join("..", "..", "testdata", "fixtures", "ruby-basic")
+	summary, err := ParseGemfileLock(root)
+	if err != nil {
+		t.Fatalf("ParseGemfileLock failed: %v", err)
+	}
+	if len(summary.Direct) != 2 {
+		t.Errorf("expected 2 gems, got %d", len(summary.Direct))
+	}
+
+	// rack should be present
+	found := false
+	for _, dep := range summary.Direct {
+		if dep.Name == "rack" {
+			found = true
+			if dep.Version != "2.2.4" {
+				t.Errorf("expected rack version 2.2.4, got %s", dep.Version)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected to find rack in gems")
+	}
+
+	// rake should be present
+	found = false
+	for _, dep := range summary.Direct {
+		if dep.Name == "rake" {
+			found = true
+			if dep.Version != "13.0.6" {
+				t.Errorf("expected rake version 13.0.6, got %s", dep.Version)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected to find rake in gems")
+	}
+}
+
+func TestParseGemfileLockNotFound(t *testing.T) {
+	summary, err := ParseGemfileLock("/nonexistent/path/that/does/not/exist")
+	if err != nil {
+		t.Fatalf("expected no error for missing Gemfile.lock, got: %v", err)
+	}
+	if len(summary.Direct) != 0 {
+		t.Errorf("expected 0 gems for missing file, got %d", len(summary.Direct))
+	}
+}


### PR DESCRIPTION
This PR adds Sprint 2 parser and CLI improvements:

- Added Maven pom.xml parser
- Added Ruby Gemfile.lock parser
- Added Go go.mod parser
- Wired Maven, Ruby and Go parsers into CLI dependency summary
- Updated terminal summary to show package counts for all ecosystems

Local checks passed:
- make build
- make test
- golangci-lint run ./...