### PR TITLE
feat: add vulnerability enrichment with CISA KEV, EPSS, and GHSA scoring

### DIFF
--- a/internal/vulnerability/enrichment.go
+++ b/internal/vulnerability/enrichment.go
@@ -1,0 +1,235 @@
+package vulnerability
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	cisaKEVURL  = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+	epssBaseURL = "https://api.first.org/data/v1/epss"
+	ghsaBaseURL = "https://api.github.com/advisories"
+)
+
+var enrichHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+type kevCatalog struct {
+	Vulnerabilities []struct {
+		CveID   string `json:"cveID"`
+		DueDate string `json:"dueDate"`
+	} `json:"vulnerabilities"`
+}
+
+type epssResponse struct {
+	Data []struct {
+		CVE        string `json:"cve"`
+		EPSS       string `json:"epss"`
+		Percentile string `json:"percentile"`
+	} `json:"data"`
+}
+
+type ghsaAdvisory struct {
+	GHSAID  string `json:"ghsa_id"`
+	HTMLURL string `json:"html_url"`
+}
+
+// fetchCISAKEV downloads the full CISA KEV catalog and indexes it by CVE ID.
+// Returns map[UPPER_CVE_ID] -> [dueDate, ""].
+func fetchCISAKEV(ctx context.Context) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cisaKEVURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := enrichHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var catalog kevCatalog
+	if err := json.Unmarshal(body, &catalog); err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(catalog.Vulnerabilities))
+	for _, v := range catalog.Vulnerabilities {
+		m[strings.ToUpper(v.CveID)] = v.DueDate
+	}
+	return m, nil
+}
+
+// fetchEPSS fetches EPSS scores in batches of 100.
+// Returns map[UPPER_CVE_ID] -> [epss_score, epss_percentile].
+func fetchEPSS(ctx context.Context, cves []string) (map[string][2]float64, error) {
+	result := make(map[string][2]float64, len(cves))
+	for i := 0; i < len(cves); i += 100 {
+		end := i + 100
+		if end > len(cves) {
+			end = len(cves)
+		}
+		url := epssBaseURL + "?cve=" + strings.Join(cves[i:end], ",")
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return result, err
+		}
+		resp, err := enrichHTTPClient.Do(req)
+		if err != nil {
+			return result, err
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return result, err
+		}
+		var epssResp epssResponse
+		if err := json.Unmarshal(body, &epssResp); err != nil {
+			continue
+		}
+		for _, e := range epssResp.Data {
+			score, _ := strconv.ParseFloat(e.EPSS, 64)
+			pct, _ := strconv.ParseFloat(e.Percentile, 64)
+			result[strings.ToUpper(e.CVE)] = [2]float64{score, pct}
+		}
+	}
+	return result, nil
+}
+
+// fetchGHSA fetches the GitHub Security Advisory for a single CVE ID.
+// Uses GITHUB_TOKEN env var if available for higher rate limits (5000/h vs 60/h).
+func fetchGHSA(ctx context.Context, cveID string) (*ghsaAdvisory, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ghsaBaseURL+"?cve_id="+cveID, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := enrichHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var advisories []ghsaAdvisory
+	if err := json.Unmarshal(body, &advisories); err != nil || len(advisories) == 0 {
+		return nil, err
+	}
+	return &advisories[0], nil
+}
+
+// computeRiskScore returns a 0–100 composite priority score and a human-readable label.
+//
+//	Score breakdown:
+//	  Severity base  : critical=40, high=30, medium=15, low=5
+//	  EPSS           : score×30 (max 30 pts — probability of exploitation)
+//	  CISA KEV bonus : +20 pts (confirmed active exploitation)
+//	  Direct dep     : +5 pts  (transitive deps are slightly less urgent)
+func computeRiskScore(v VulnerabilityResult) (float64, string) {
+	var score float64
+	switch v.Severity {
+	case "critical":
+		score += 40
+	case "high":
+		score += 30
+	case "medium":
+		score += 15
+	case "low":
+		score += 5
+	}
+	score += v.EPSSScore * 30
+	if v.InCISAKEV {
+		score += 20
+	}
+	if !v.IsTransitive {
+		score += 5
+	}
+	if score > 100 {
+		score = 100
+	}
+	switch {
+	case score >= 70:
+		return score, "Critical Priority"
+	case score >= 50:
+		return score, "High Priority"
+	case score >= 30:
+		return score, "Medium Priority"
+	default:
+		return score, "Low Priority"
+	}
+}
+
+// EnrichResults fetches CISA KEV, EPSS, and GitHub advisory data for every
+// vulnerability in results and computes a composite risk score. All API calls
+// are best-effort; failures leave the existing fields at their zero values.
+func EnrichResults(ctx context.Context, results *ScanResults) {
+	if len(results.Vulnerabilities) == 0 {
+		return
+	}
+
+	// Collect unique CVE IDs (GHSA IDs already link directly to GitHub)
+	seen := make(map[string]struct{})
+	var cveList []string
+	for _, v := range results.Vulnerabilities {
+		id := strings.ToUpper(v.Vulnerability)
+		if strings.HasPrefix(id, "CVE-") {
+			if _, dup := seen[id]; !dup {
+				seen[id] = struct{}{}
+				cveList = append(cveList, id)
+			}
+		}
+	}
+
+	kevMap, _ := fetchCISAKEV(ctx)
+	epssMap, _ := fetchEPSS(ctx, cveList)
+
+	// GHSA: limit to first 15 critical/high CVEs to respect unauthenticated rate limit
+	ghsaCache := make(map[string]*ghsaAdvisory)
+	ghsaFetches := 0
+
+	for i := range results.Vulnerabilities {
+		v := &results.Vulnerabilities[i]
+		upperID := strings.ToUpper(v.Vulnerability)
+
+		if dueDate, ok := kevMap[upperID]; ok {
+			v.InCISAKEV = true
+			v.KEVDueDate = dueDate
+		}
+
+		if epss, ok := epssMap[upperID]; ok {
+			v.EPSSScore = epss[0]
+			v.EPSSPercentile = epss[1]
+		}
+
+		if strings.HasPrefix(upperID, "CVE-") && (v.Severity == "critical" || v.Severity == "high") {
+			if adv, alreadySeen := ghsaCache[upperID]; alreadySeen {
+				if adv != nil {
+					v.GHSAAdvisoryID = adv.GHSAID
+					v.GHSAURL = adv.HTMLURL
+				}
+			} else if ghsaFetches < 15 {
+				adv, err := fetchGHSA(ctx, upperID)
+				ghsaFetches++
+				ghsaCache[upperID] = adv
+				if err == nil && adv != nil {
+					v.GHSAAdvisoryID = adv.GHSAID
+					v.GHSAURL = adv.HTMLURL
+				}
+			}
+		}
+
+		v.RiskScore, v.RiskLabel = computeRiskScore(*v)
+	}
+}

--- a/internal/vulnerability/scanner.go
+++ b/internal/vulnerability/scanner.go
@@ -10,13 +10,22 @@ import (
 
 // VulnerabilityResult represents a found vulnerability.
 type VulnerabilityResult struct {
-	PackageName   string
-	PackageType   string
-	Vulnerability string
-	Severity      string
-	Location      string
-	IsTestData    bool
-	IsTransitive  bool
+	PackageName    string
+	PackageType    string
+	Vulnerability  string
+	Severity       string
+	Location       string
+	IsTestData     bool
+	IsTransitive   bool
+	Number         int
+	InCISAKEV      bool
+	KEVDueDate     string
+	EPSSScore      float64
+	EPSSPercentile float64
+	GHSAAdvisoryID string
+	GHSAURL        string
+	RiskScore      float64
+	RiskLabel      string
 }
 
 // ScanResults contains all vulnerability scan results.
@@ -52,14 +61,9 @@ func ScanWithGrype(ctx context.Context, scanPath string) (*ScanResults, error) {
 		Vulnerabilities: make([]VulnerabilityResult, 0),
 	}
 
-	// Check if grype is available
-	grypeCmd := "grype"
-	if _, err := exec.LookPath("grype"); err != nil {
-		// Try current directory
-		if _, err := exec.LookPath("./grype"); err != nil {
-			return nil, fmt.Errorf("grype not found in PATH or current directory - please install grype: https://github.com/anchore/grype")
-		}
-		grypeCmd = "./grype"
+	grypeCmd := getGrypeCommand()
+	if grypeCmd == "" {
+		return nil, fmt.Errorf("grype not found in PATH or current directory - please install grype: https://github.com/anchore/grype")
 	}
 
 	// Run Grype with JSON output


### PR DESCRIPTION
Add enrichment.go: fetches CISA KEV catalog, EPSS scores (batched), and GitHub Security Advisories for critical/high CVEs. Extend VulnerabilityResult with InCISAKEV, KEVDueDate, EPSSScore, EPSSPercentile, GHSAAdvisoryID, GHSAURL, RiskScore, RiskLabel fields. Add computeRiskScore(): weighted 0-100 composite score using severity base, EPSS x30, CISA KEV bonus (+20), and direct-dep bonus (+5). Add EnrichResults(): orchestrates all three enrichments, best-effort. Consolidate ScanWithGrype to use getGrypeCommand().

## Summary

More descriptive vulnerability scoring system.

## Testing

- [ ] `go test ./...`
- [ ] `go vet ./...`
- [ ] docs updated when behavior changed
